### PR TITLE
Bugfix to extract openfst version

### DIFF
--- a/compile-kaldi.sh
+++ b/compile-kaldi.sh
@@ -3,7 +3,7 @@
 cd ${WORKING_DIR}/kaldi/tools
 
 # tools directory --> we'll only compile OpenFST
-OPENFST_VERSION=$(grep -oP "OPENFST_VERSION *= *\K(.*)$" ${WORKING_DIR}/kaldi/tools/Makefile)
+OPENFST_VERSION=$(grep -oP "OPENFST_VERSION *\?= *\K(.*)$" ${WORKING_DIR}/kaldi/tools/Makefile)
 wget -T 10 -t 1 http://openfst.cs.nyu.edu/twiki/pub/FST/FstDownload/openfst-${OPENFST_VERSION}.tar.gz
 tar -zxvf openfst-${OPENFST_VERSION}.tar.gz
 cd openfst-${OPENFST_VERSION}/


### PR DESCRIPTION
The current version of kaldi seem to optionally specify the openfst version with ?= in the makefile. This fix corrects the regexp to extract the openfst version from the makefile.

I tested the fix by building kaldi and running a test decode according to http://kaldi-asr.org/doc/online_decoding.html#online_decoding_nnet2_example. Everything seems to be working fine.

This should fix #3 and I also cannot reproduce #4.