### PR TITLE
fix(kaldi-compil): Add Cub compilation

### DIFF
--- a/compile-kaldi.sh
+++ b/compile-kaldi.sh
@@ -14,6 +14,8 @@ make install
 # source directory
 cd ..
 ln -s openfst-${OPENFST_VERSION} openfst
+cd ../tools
+make cub
 cd ../src
 CXX=clang++ ./configure --static --android-incdir=${ANDROID_TOOLCHAIN_PATH}/sysroot/usr/include/ --host=arm-linux-androideabi --openblas-root=${WORKING_DIR}/OpenBLAS/install
 sed -i 's/-g # -O0 -DKALDI_PARANOID/-O3 -DNDEBUG/g' kaldi.mk


### PR DESCRIPTION
Fix the bug during compilation: ***configure failed: Could not find file /cub/cub.cuh